### PR TITLE
synchronize pagination and SelectYearButtons

### DIFF
--- a/src/components/Site.tsx
+++ b/src/components/Site.tsx
@@ -152,13 +152,12 @@ export function GithubButton() {
   )
 }
 
-export function SelectYearButtons() {
+export function SelectYearButtons({startYear} : { startYear: number }) {
 
-  const current_year = new Date().getFullYear();
-  const start_year = 2015;
+  const currentYear = new Date().getFullYear();
   const years = [];
 
-  for (let y = start_year; y <= current_year; y++) {
+  for (let y = startYear; y <= currentYear; y++) {
     years.push(y);
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,14 +9,16 @@ import List from './routes/List.jsx'
 import AppTheme from './theme.tsx'
 import { ChakraProvider } from '@chakra-ui/react'
 
+const START_YEAR = 2015;
+
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <Root />,
+    element: <Root startYear={START_YEAR} />,
   },
   {
     path: "/:year",
-    element: <List />,
+    element: <List startYear={START_YEAR}/>,
   },
 ]);
 

--- a/src/routes/List.tsx
+++ b/src/routes/List.tsx
@@ -18,7 +18,7 @@ import {
   Spacer
 } from '@chakra-ui/react';
 
-function List() {
+function List({ startYear} : {startYear: number}) {
   let { year: param_year } = useParams();
   const year = parseInt(param_year as string);
   const prev_year = year - 1;
@@ -102,11 +102,15 @@ function List() {
               { year }年 開催イベント
             </Heading>
             <Spacer />
-            <Button size={'xs'}
-                    variant={'ghost'}
-                    colorScheme={'impact'}
-                    onClick={() => {window.open('/' + prev_year, '_self')}}
+            {
+              prev_year >= startYear && (
+                    <Button size={'xs'}
+                            variant={'ghost'}
+                            colorScheme={'impact'}
+                            onClick={() => {window.open('/' + prev_year, '_self')}}
                     >← { prev_year }年</Button>
+                )
+            }
             <Button size={'xs'}
                     variant={'ghost'}
                     colorScheme={'impact'}
@@ -142,7 +146,7 @@ function List() {
                 p={{base: '4', md: '0'}}
                 >
             <CardBody>
-              <SelectYearButtons />
+              <SelectYearButtons startYear={startYear}/>
             </CardBody>
           </Card>
         </Stack>

--- a/src/routes/Root.tsx
+++ b/src/routes/Root.tsx
@@ -19,7 +19,7 @@ import {
 } from '@chakra-ui/react';
 import { ExternalLinkIcon } from "@chakra-ui/icons";
 
-function Root() {
+function Root({startYear}: {startYear: number}) {
   const [data, setData] = useState({
     isLoading: true,
     pastEvents: [],
@@ -201,7 +201,7 @@ function Root() {
                 padding={{base: '4', md: '0'}}
                 >
             <CardBody>
-              <SelectYearButtons />
+              <SelectYearButtons startYear={startYear}/>
             </CardBody>
           </Card>
         </Stack>


### PR DESCRIPTION
The SelectYearButtons component displays years up to 2015. 
However, the pagination allows users to go back to previous years indefinitely. 
I want to synchronize the pagination with the SelectYearButtons component so that the available years are consistent.

## BEFORE
![image](https://github.com/user-attachments/assets/cbbe952e-27fe-4284-acbe-5a585e964fe3)



## AFTER
![Screenshot from 2025-05-12 10-27-58](https://github.com/user-attachments/assets/e46125b0-14f6-4cb5-89d1-a7e3d24e71f7)


# FYI
Infinite pagination is possible for future years, but this PR is not fix it.